### PR TITLE
refactor: 각종 API호출부 react-query 추가

### DIFF
--- a/app/components/categories/categories-navbar.tsx
+++ b/app/components/categories/categories-navbar.tsx
@@ -7,6 +7,7 @@ import {
   setCategoryId,
 } from '@/redux/features/categories-slice';
 import { useDeviceDetect } from '@/app/hooks/use-device-detect';
+import { useGuildCategories } from '@/app/lib/api/guilds';
 import ColsSelectButton from '../base/cols-select-button';
 import TypeSelector from '../posts/type-selector';
 
@@ -18,9 +19,8 @@ const getButtonCSS = (clicked: boolean) => {
 };
 
 export default function CategoriesNavbar({ guildName }: { guildName: string }) {
-  const categories = useAppSelector(
-    (state) => state.categoriesSlice.categories,
-  );
+  const { data: categories } = useGuildCategories(guildName);
+
   const categoriId = useAppSelector(
     (state) => state.categoriesSlice.categoryId,
   );
@@ -41,7 +41,7 @@ export default function CategoriesNavbar({ guildName }: { guildName: string }) {
         <TypeSelector />
       </div>
       <div className="flex overflow-scroll no-scrollbar justify-start items-center gap-2 md:gap-6 lg:gap-8">
-        {categories.map((category) => (
+        {categories?.map((category) => (
           <div key={category.id} className="flex-none">
             <button
               type="submit"

--- a/app/components/posts/post-preview.tsx
+++ b/app/components/posts/post-preview.tsx
@@ -95,7 +95,7 @@ export default function PostPreview({ type, post, cols }: Props) {
           </div>
         )}
         {!thumbnail && (
-          <div className="flex px-10 md:px-14 text-xs md:text-sm text-base">
+          <div className="flex px-10 md:px-14 md:text-sm text-base">
             <ReadMore text={post.content} maxLine={0} />
           </div>
         )}

--- a/app/hooks/use-infinite-scroll.ts
+++ b/app/hooks/use-infinite-scroll.ts
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 export const useInfiniteScroll = (
   ref: React.RefObject<any>,
   fetchNext: () => void,
+  hasNext?: boolean,
 ) => {
   useEffect(() => {
     if (!ref.current) return undefined;
@@ -10,7 +11,7 @@ export const useInfiniteScroll = (
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting) {
+          if (entry.isIntersecting && !!hasNext) {
             fetchNext();
           }
         });
@@ -20,7 +21,8 @@ export const useInfiniteScroll = (
         threshold: 1,
       },
     );
+
     observer.observe(ref.current);
     return () => observer.disconnect();
-  }, [ref, fetchNext]);
+  }, [ref, fetchNext, hasNext]);
 };

--- a/app/lib/api/guilds.ts
+++ b/app/lib/api/guilds.ts
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 import { Category, Guild } from 'prisma';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
 import { client } from '../client';
 
 function parseCategories(categoriesData: any): Array<Category> {
@@ -28,3 +30,11 @@ export async function getGuilds() {
   });
   return res.data;
 }
+
+export const useGuildCategories = (guildName: string) =>
+  useQuery([guildName], () => client.get(`/guilds/${guildName}/categories`), {
+    select: (data: AxiosResponse<Guild[]>) => parseCategories(data.data),
+  });
+
+export const useGuilds = () =>
+  useQuery(['get-guild'], () => client.get('/guilds'));

--- a/app/lib/api/guilds.ts
+++ b/app/lib/api/guilds.ts
@@ -42,4 +42,4 @@ export const useGuildCategories = (guildName: string) =>
   );
 
 export const useGuilds = () =>
-  useQuery(guildKeys.guild().queryKey, () => client.get('/guilds'));
+  useQuery(guildKeys.guild.queryKey, () => client.get('/guilds'));

--- a/app/lib/api/guilds.ts
+++ b/app/lib/api/guilds.ts
@@ -3,6 +3,7 @@ import { Category, Guild } from 'prisma';
 import { useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { client } from '../client';
+import { guildKeys } from '../query-key-factory';
 
 function parseCategories(categoriesData: any): Array<Category> {
   return _.map(categoriesData, (categoryData) =>
@@ -32,9 +33,13 @@ export async function getGuilds() {
 }
 
 export const useGuildCategories = (guildName: string) =>
-  useQuery([guildName], () => client.get(`/guilds/${guildName}/categories`), {
-    select: (data: AxiosResponse<Guild[]>) => parseCategories(data.data),
-  });
+  useQuery(
+    guildKeys.category(guildName).queryKey,
+    () => client.get(`/guilds/${guildName}/categories`),
+    {
+      select: (data: AxiosResponse<Guild[]>) => parseCategories(data.data),
+    },
+  );
 
 export const useGuilds = () =>
-  useQuery(['get-guild'], () => client.get('/guilds'));
+  useQuery(guildKeys.guild().queryKey, () => client.get('/guilds'));

--- a/app/lib/api/posts.ts
+++ b/app/lib/api/posts.ts
@@ -2,6 +2,7 @@ import { Post } from 'prisma';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { client } from '../client';
+import { postKeys } from '../query-key-factory';
 
 export type Posts = {
   posts: Post[];
@@ -10,7 +11,7 @@ export type Posts = {
 };
 
 export const useInfinitePosts = (categoryId: string, type: string) =>
-  useInfiniteQuery(['posts', categoryId, type], {
+  useInfiniteQuery(postKeys.list(categoryId, type).queryKey, {
     queryFn: async ({ pageParam = '' }) => {
       const res = await client.get<Posts>(
         `/categories/${categoryId}/posts?type=${type}&cursor=${pageParam}`,
@@ -22,6 +23,6 @@ export const useInfinitePosts = (categoryId: string, type: string) =>
   });
 
 export const usePost = (id: string) =>
-  useQuery(['posts', id], () => client.get(`/posts/${id}`), {
+  useQuery(postKeys.detail(id).queryKey, () => client.get(`/posts/${id}`), {
     select: (data: AxiosResponse<Post>) => data.data,
   });

--- a/app/lib/api/posts.ts
+++ b/app/lib/api/posts.ts
@@ -1,4 +1,6 @@
 import { Post } from 'prisma';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
 import { client } from '../client';
 
 export type Posts = {
@@ -7,18 +9,19 @@ export type Posts = {
   hasNextPage: boolean;
 };
 
-export async function getPosts(
-  categoryId: string,
-  type: string,
-  cursor: string,
-) {
-  const res = await client.get<Posts>(
-    `/categories/${categoryId}/posts?type=${type}&cursor=${cursor}`,
-  );
-  return res.data;
-}
+export const useInfinitePosts = (categoryId: string, type: string) =>
+  useInfiniteQuery(['posts', categoryId, type], {
+    queryFn: async ({ pageParam = '' }) => {
+      const res = await client.get<Posts>(
+        `/categories/${categoryId}/posts?type=${type}&cursor=${pageParam}`,
+      );
+      return res.data;
+    },
+    getNextPageParam: (lastPage) => lastPage.cursor,
+    enabled: !!categoryId,
+  });
 
-export async function getPost(id: string) {
-  const res = await client.get<Post>(`/posts/${id}`);
-  return res.data;
-}
+export const usePost = (id: string) =>
+  useQuery(['posts', id], () => client.get(`/posts/${id}`), {
+    select: (data: AxiosResponse<Post>) => data.data,
+  });

--- a/app/lib/query-key-factory.ts
+++ b/app/lib/query-key-factory.ts
@@ -5,9 +5,7 @@ import {
 } from '@lukemorales/query-key-factory';
 
 export const guildKeys = createQueryKeys('guilds', {
-  guild: () => ({
-    queryKey: ['guilds'],
-  }),
+  guild: null,
   category: (guildName: string) => ({
     queryKey: [guildName, 'categories'],
   }),

--- a/app/lib/query-key-factory.ts
+++ b/app/lib/query-key-factory.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+  createQueryKeys,
+  mergeQueryKeys,
+} from '@lukemorales/query-key-factory';
+
+export const guildKeys = createQueryKeys('guilds', {
+  guild: () => ({
+    queryKey: ['guilds'],
+  }),
+  category: (guildName: string) => ({
+    queryKey: [guildName, 'categories'],
+  }),
+});
+
+export const postKeys = createQueryKeys('posts', {
+  list: (categoryId: string, type: string) => ({
+    queryKey: ['posts', categoryId, type],
+  }),
+  detail: (postId: string) => ({
+    queryKey: ['post', postId],
+  }),
+});
+
+export const queryKeys = mergeQueryKeys(guildKeys, postKeys);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { ReduxProviders } from '@/redux/provider';
 import { SessionProvider } from 'next-auth/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const queryClient = new QueryClient();
 
@@ -17,6 +18,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <ReduxProviders>
       <QueryClientProvider client={queryClient}>
         <SessionProvider>{children}</SessionProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </ReduxProviders>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,7 +6,13 @@ import { SessionProvider } from 'next-auth/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 export function Providers({ children }: { children: React.ReactNode }) {
   // zustand devtools

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@material-tailwind/react": "^2.0.3",
     "@reduxjs/toolkit": "^1.9.5",
     "@tanstack/react-query": "^4.29.15",
-    "@tanstack/react-query-devtools": "^4.29.15",
+    "@tanstack/react-query-devtools": "^4.29.25",
     "@types/lodash": "^4.14.195",
     "@types/node": "20.1.4",
     "@types/react": "18.2.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@heroicons/react": "^2.0.18",
+    "@lukemorales/query-key-factory": "^1.3.2",
     "@material-tailwind/react": "^2.0.3",
     "@reduxjs/toolkit": "^1.9.5",
     "@tanstack/react-query": "^4.29.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4265,18 +4265,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-query-devtools@npm:^4.29.15":
-  version: 4.29.23
-  resolution: "@tanstack/react-query-devtools@npm:4.29.23"
+"@tanstack/react-query-devtools@npm:^4.29.25":
+  version: 4.29.25
+  resolution: "@tanstack/react-query-devtools@npm:4.29.25"
   dependencies:
     "@tanstack/match-sorter-utils": ^8.7.0
     superjson: ^1.10.0
     use-sync-external-store: ^1.2.0
   peerDependencies:
-    "@tanstack/react-query": 4.29.23
+    "@tanstack/react-query": 4.29.25
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 24319cf8a7c9f0b71e77b542eec265a44db81e5206ab7665d48651ee8ff762e168445bc58dcc27c1ec4e0401b40de7f3922c88c5734e59ecc4cb933977d527a6
+  checksum: 2861f78de92a5c7595221383d9e60a70eafd0b1ed08313b624697fb221a1e6694200c14f4f5c3c2ef9ee0b1a525f7b7f04d3e0587b32b7a73cfb2d466d3e98af
   languageName: node
   linkType: hard
 
@@ -15718,7 +15718,7 @@ __metadata:
     "@storybook/react": 7.0.20
     "@storybook/testing-library": 0.0.14-next.2
     "@tanstack/react-query": ^4.29.15
-    "@tanstack/react-query-devtools": ^4.29.15
+    "@tanstack/react-query-devtools": ^4.29.25
     "@types/lodash": ^4.14.195
     "@types/node": 20.1.4
     "@types/react": 18.2.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,6 +2492,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lukemorales/query-key-factory@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@lukemorales/query-key-factory@npm:1.3.2"
+  peerDependencies:
+    "@tanstack/query-core": ">= 4.0.0"
+    "@tanstack/react-query": ">= 4.0.0"
+  checksum: b7eec057a8dabe8dae0f0b307279127488437f213b93fb899aceff32385bd9eef0e4ae9a8354d45b7073421b7ca58494261f34d00adfcae432d821b3222291fd
+  languageName: node
+  linkType: hard
+
 "@material-tailwind/react@npm:^2.0.3":
   version: 2.0.6
   resolution: "@material-tailwind/react@npm:2.0.6"
@@ -15707,6 +15717,7 @@ __metadata:
   resolution: "wtb-web@workspace:."
   dependencies:
     "@heroicons/react": ^2.0.18
+    "@lukemorales/query-key-factory": ^1.3.2
     "@material-tailwind/react": ^2.0.3
     "@next/eslint-plugin-next": 13.4.8
     "@reduxjs/toolkit": ^1.9.5


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
`react-query` 활용성 증대

## 어떻게 해결했나요?
- `axiosClient`를 직접호출하여 헤더값을 관리하는 부분을 `useQuery`, `useInfiniteQuery`로 감싸서 `react-query`에서 기본 제공하는 캐싱 등을 활용하게 변경.
- `react-query-devtools` 추가.

## 참고 자료

- `react-query` 적용 후 변경점: 캐싱이 적절히 작동하여, 불필요한 재호출이 없어짐. (`catergory`의 경우 아직 `redux`가 남아있어서 두번 호출)

| 기존  | 변경후  |
|---|---|
|![image](https://github.com/wtb-kr/wtb-web/assets/40153724/ad00f7b3-f223-46f3-abe6-312ba2f08292)| ![image](https://github.com/wtb-kr/wtb-web/assets/40153724/06b23c0c-175c-41db-a2da-d98a2917b122)|

- `react-query-devtools` : 화면 좌하단의 꽃 모양을 클릭하여 팝업형태로 사용.
 
![image](https://github.com/wtb-kr/wtb-web/assets/40153724/187c89ed-bfd9-479c-9c82-d03093130a26)
