### PR TITLE
refactor: material/tailwind(popover) -> mui(popper)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     'react/react-in-jsx-scope': OFF,
     'react/require-default-props': OFF,
     'react/jsx-pascal-case': ERROR,
+    'react/jsx-props-no-spreading': [ERROR, { exceptions: ['Fade'] }],
     'prettier/prettier': ERROR,
     'import/prefer-default-export': OFF,
     'no-nested-ternary': OFF,
@@ -60,6 +61,10 @@ module.exports = {
       {
         selector: 'objectLiteralProperty',
         format: null,
+      },
+      {
+        selector: 'parameter',
+        format: ['camelCase', 'PascalCase'],
       },
     ],
     'check-file/filename-naming-convention': [

--- a/app/components/base/popper.tsx
+++ b/app/components/base/popper.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import useClickOutside from '@/app/hooks/use-click-outside';
-/* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable react/jsx-props-no-spreading */
 import { Fade, Popper as MUIPopper } from '@mui/material';
 import { PopperProps as MUIPopperProps } from '@mui/material/Popper';
 import { useRef } from 'react';

--- a/app/components/base/popper.tsx
+++ b/app/components/base/popper.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import useClickOutside from '@/app/hooks/use-click-outside';
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable react/jsx-props-no-spreading */
+import { Fade, Popper as MUIPopper } from '@mui/material';
+import { PopperProps as MUIPopperProps } from '@mui/material/Popper';
+import { useRef } from 'react';
+
+interface PopperProps extends MUIPopperProps {
+  handler: () => void;
+  delay?: number;
+  children: React.ReactNode;
+}
+export default function Popper({
+  open,
+  anchorEl,
+  handler,
+  placement = 'bottom-start',
+  delay = 350,
+  children,
+}: PopperProps) {
+  const popperRef = useRef(null);
+
+  useClickOutside(popperRef, handler);
+
+  return (
+    <MUIPopper
+      ref={popperRef}
+      open={open}
+      anchorEl={anchorEl}
+      placement={placement}
+      transition
+    >
+      {({ TransitionProps }) => (
+        <Fade {...TransitionProps} timeout={delay}>
+          <div>{children}</div>
+        </Fade>
+      )}
+    </MUIPopper>
+  );
+}

--- a/app/components/users/user-profile.tsx
+++ b/app/components/users/user-profile.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-/* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable react/jsx-props-no-spreading */
 import { Typography } from '@mui/material';
 import { User } from 'prisma';
 import _ from 'lodash';

--- a/app/components/users/user-profile.tsx
+++ b/app/components/users/user-profile.tsx
@@ -1,19 +1,17 @@
 'use client';
 
-import React from 'react';
-import {
-  Popover,
-  PopoverHandler,
-  PopoverContent,
-  Typography,
-} from '@material-tailwind/react';
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable react/jsx-props-no-spreading */
+import { Typography } from '@mui/material';
 import { User } from 'prisma';
 import _ from 'lodash';
 import { useDeviceDetect } from '@/app/hooks/use-device-detect';
+import { useState } from 'react';
 import UserAvatar from './user-avatar';
 import Roles from './roles';
 import SocialJoinDates from './social-join-dates';
 import DmDialog from '../base/dm-dialog';
+import Popper from '../base/popper';
 import Username from './user-name';
 
 export default function UserProfile({
@@ -27,8 +25,18 @@ export default function UserProfile({
   displayUsername: boolean;
   displayDM: boolean;
 }) {
-  const [openPopover, setOpenPopover] = React.useState(false);
   const device = useDeviceDetect();
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handlePopoverOpen = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+
   const getDiscordSocialID = () => {
     const account = _.find(
       user.socialAccounts,
@@ -38,49 +46,54 @@ export default function UserProfile({
   };
 
   return (
-    <Popover open={openPopover} handler={setOpenPopover}>
-      <PopoverHandler>
-        <button type="button">
-          {device === 'mobile' && (
-            <div className="flex gap-2 items-center font-medium text-xs">
-              {displayAvatar && <UserAvatar user={user} size="xs" />}
-              {displayUsername && <Username user={user} />}
+    <>
+      <button type="button" onClick={handlePopoverOpen}>
+        {device === 'mobile' && (
+          <div className="flex gap-2 items-center font-medium text-xs">
+            {displayAvatar && <UserAvatar user={user} size="xs" />}
+            {displayUsername && <Username user={user} />}
+          </div>
+        )}
+        {device === 'browser' && (
+          <div className="flex gap-2 items-center font-medium text-base">
+            {displayAvatar && <UserAvatar user={user} size="sm" />}
+            {displayUsername && <Username user={user} />}
+          </div>
+        )}
+      </button>
+      <Popper
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        handler={handlePopoverClose}
+      >
+        <div className="max-w-xs z-50 bg-white p-4 border rounded-lg drop-shadow-lg">
+          <div className="mb-2 flex items-center justify-between gap-4">
+            <UserAvatar user={user} size="md" />
+            {displayDM && (
+              <DmDialog
+                url={`https://discord.com/users/${getDiscordSocialID()}`}
+              />
+            )}
+          </div>
+          <Typography
+            variant="caption"
+            color="blue-gray"
+            className="mb-2 flex items-center text-base"
+          >
+            <span className="font-semibold">{user.username}</span>
+          </Typography>
+          <Typography variant="caption" color="gray" className="font-normal">
+            <div>
+              <div className="font-semibold">가입시기</div>
+              <SocialJoinDates socialAccounts={user.socialAccounts} />
             </div>
-          )}
-          {device === 'browser' && (
-            <div className="flex gap-2 items-center font-medium text-base">
-              {displayAvatar && <UserAvatar user={user} size="sm" />}
-              {displayUsername && <Username user={user} />}
+            <div className="mt-1">
+              <div className="font-semibold">역할</div>
+              <Roles roles={user.roles} />
             </div>
-          )}
-        </button>
-      </PopoverHandler>
-      <PopoverContent className="max-w-xs z-50">
-        <div className="mb-2 flex items-center justify-between gap-4">
-          <UserAvatar user={user} size="md" />
-          {displayDM && (
-            <DmDialog
-              url={`https://discord.com/users/${getDiscordSocialID()}`}
-            />
-          )}
+          </Typography>
         </div>
-        <Typography
-          color="blue-gray"
-          className="mb-2 flex items-center text-base"
-        >
-          <span className="font-semibold">{user.username}</span>
-        </Typography>
-        <Typography variant="small" color="gray" className="font-normal">
-          <div>
-            <div className="font-semibold">가입시기</div>
-            <SocialJoinDates socialAccounts={user.socialAccounts} />
-          </div>
-          <div className="mt-1">
-            <div className="font-semibold">역할</div>
-            <Roles roles={user.roles} />
-          </div>
-        </Typography>
-      </PopoverContent>
-    </Popover>
+      </Popper>
+    </>
   );
 }

--- a/app/hooks/use-click-outside.ts
+++ b/app/hooks/use-click-outside.ts
@@ -1,0 +1,32 @@
+import { useEffect, RefObject, useCallback } from 'react';
+
+type Event = MouseEvent | TouchEvent;
+
+/**
+ * @description Hook that handles click outside of a component
+ * @param ref - React ref object
+ * @param handler - function to be called when click outside
+ */
+const useClickOutside = (
+  ref: RefObject<HTMLElement>,
+  handler: (event: Event) => void,
+) => {
+  const handleClickOutside = useCallback(
+    (event: Event) => {
+      if (ref?.current && !ref.current.contains(event.target as Node)) {
+        handler(event);
+      }
+    },
+    [ref, handler],
+  );
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+      document.addEventListener('touchstart', handleClickOutside);
+    };
+  }, [handleClickOutside]);
+};
+
+export default useClickOutside;

--- a/app/hooks/use-click-outside.ts
+++ b/app/hooks/use-click-outside.ts
@@ -21,10 +21,8 @@ const useClickOutside = (
   );
   useEffect(() => {
     document.addEventListener('click', handleClickOutside);
-    document.addEventListener('touchstart', handleClickOutside);
     return () => {
       document.removeEventListener('click', handleClickOutside);
-      document.addEventListener('touchstart', handleClickOutside);
     };
   }, [handleClickOutside]);
 };


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
popover 마이그레이션 중 mui에서 제공하는 popover가 scroll이 고정되는 문제가 있었습니다 

## 어떻게 해결했나요?
- popover에서 `disableScrollLock={true}` 을 주어 해결하려 했지만, 요소가 클릭한 버튼에 고정되어 있지 않고 화면 기준으로 고정되는 문제가 있어서 popper 컴포넌트를 일반화하여 적용하였습니다

## 참고 자료
- https://stackoverflow.com/questions/53985436/material-ui-unblock-scrolling-when-popover-is-opened
- https://mui.com/material-ui/api/popper/