### PR TITLE
refactor: avatar 전환 작업

### DIFF
--- a/app/components/base/avatar.tsx
+++ b/app/components/base/avatar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import Image from 'next/image';
-
+import { Avatar as MuiAvatar } from '@mui/material';
 export default function Avatar({
   name,
   avatarURL,
@@ -10,13 +9,11 @@ export default function Avatar({
   avatarURL?: string | null;
 }) {
   return (
-    <Image
-      src={avatarURL || '/dongwang-gray.svg'}
+    <MuiAvatar
       alt={`${name} avatar`}
-      className="dark:invert rounded-full"
-      width={32}
-      height={32}
-      priority
+      src={avatarURL || '/dongwang-gray.svg'}
+      className="rounded-full w-8 h-8 bg-zinc-200"
+      variant="rounded"
     />
   );
 }

--- a/app/components/users/user-avatar.tsx
+++ b/app/components/users/user-avatar.tsx
@@ -1,14 +1,32 @@
 import { User } from 'prisma';
-import { Avatar } from '@material-tailwind/react';
+import { Avatar as MuiAvatar } from '@mui/material';
 
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
+const convertAvatarSize = (avatarSize: Size): string => {
+  if (avatarSize === 'xs') return '24px';
+  if (avatarSize === 'sm') return '36px';
+  if (avatarSize === 'md') return '48px';
+  if (avatarSize === 'lg') return '60px';
+  if (avatarSize === 'xl') return '72px';
+  if (avatarSize === 'xxl') return '84px';
+
+  return '24px';
+};
+
 export default function UserAvatar({ user, size }: { user: User; size: Size }) {
+  const avatarSize = convertAvatarSize(size);
+
   return (
-    <Avatar
-      src={user.avatarURL ? user.avatarURL : '/dongwang-gray.svg'}
+    <MuiAvatar
       alt={`${user.username} avatar`}
-      size={size}
+      src={user.avatarURL || '/dongwang-gray.svg'}
+      sx={{
+        width: avatarSize,
+        height: avatarSize,
+      }}
+      className="rounded-full bg-zinc-200"
+      variant="rounded"
     />
   );
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
- Avatar 컴포넌트 MUI 컴포넌트 적용 
- 배경이 없는 채널 이모지 아바타 배경 적용
- 
## 어떻게 해결했나요?
- 기존 로그인 위치의 아바타는 next의 Image -> Mui Avatar 컴포넌트로 적용 
- material-tailwind에서 제공하는 Avatar 컴포넌트의 size를 px로 변환 후 MuiAvatar 스타일 적용 
-

## 참고 자료
- https://mui.com/material-ui/react-avatar/