### PR TITLE
feat: 경매 화면 기본 뷰 추가

### DIFF
--- a/app/components/auctions/auction-detail.tsx
+++ b/app/components/auctions/auction-detail.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Dialog, DialogHeader } from '@material-tailwind/react';
+import { Auction } from 'prisma';
+import moment from 'moment';
+import { getPostTitle, getPrice } from '@/app/lib/post';
+import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
+import remarkGfm from 'remark-gfm';
+import UserProfile from '../users/user-profile';
+import ImageCarousel from '../base/image-carousel';
+
+export default function AuctionDetailCard({
+  auction,
+  open,
+  handleOpen,
+}: {
+  auction: Auction;
+  open: boolean;
+  handleOpen: React.MouseEventHandler;
+}) {
+  const sizes = 'w-full h-full';
+
+  return (
+    <Dialog
+      open={open}
+      handler={handleOpen}
+      className="overflow-scroll no-scrollbar max-w-[90vw] max-h-[90vh]"
+    >
+      <DialogHeader className="p-0">
+        <div className="flex flex-col md:flex-row w-full max-h-full">
+          <div className="rounded-tl-md rounded-bl-none rounded-tr-md md:rounded-tl-md md:rounded-bl-md md:rounded-tr-none">
+            <ImageCarousel
+              images={auction.images}
+              sizes={sizes}
+              width={1920}
+              height={1920}
+            />
+          </div>
+          <div className="flex-none max-w-xs lg:max-w-sm border-t-2 md:border-t-0 border-l-0 md:border-l-2 border-gray-100 line-break">
+            <div className="p-2 font-medium">
+              <div className="flex flex-row gap-2 text-sm md:text-base items-center">
+                <UserProfile
+                  user={auction.user}
+                  displayAvatar
+                  displayUsername
+                  displayDM
+                />
+                <div className="justify-self-end text-[10px] md:text-xs text-gray-600">
+                  {moment(auction.createdAt).fromNow()}
+                </div>
+              </div>
+              <div className="p-2 flex flex-row gap-2 justify-between items-center">
+                <div className="text-sm md:text-base font-semibold">
+                  {getPostTitle(auction)}
+                </div>
+                <div className="flex-none text-sm md:text-base justify-self-end">
+                  {getPrice(auction)}
+                </div>
+              </div>
+              <div className="p-2 pt-4 text-sm md:text-base">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {auction.content}
+                </ReactMarkdown>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogHeader>
+    </Dialog>
+  );
+}

--- a/app/components/auctions/auction-preview.tsx
+++ b/app/components/auctions/auction-preview.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import _ from 'lodash';
+import { Auction } from 'prisma';
+import moment from 'moment';
+import 'moment/locale/ko';
+import { getPostTitle, getPrice } from '@/app/lib/post';
+import { useState } from 'react';
+import { ChatBubbleOvalLeftIcon } from '@heroicons/react/24/outline';
+import PostDetail from './auction-detail';
+import UserProfile from '../users/user-profile';
+import ReadMore from '../base/read-more';
+import Thumbnail from '../base/thumbnail';
+
+interface Props {
+  type: string;
+  auction: Auction;
+  cols: number;
+}
+
+export default function AuctionPreview({ type, auction, cols }: Props) {
+  const sizes =
+    type === 'buy'
+      ? 'w-48 h-36 md:w-96 md:h-72'
+      : cols === 1
+      ? 'w-96 h-72'
+      : 'w-48 sm:w-72 md:w-96 h-36 md:h-72';
+  const thumbnail = _.get(auction.images, '[0]');
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(!open);
+  };
+
+  if (type === 'buy') {
+    return (
+      <div className="flex flex-col overflow-hidden shadow line-break max-w-lg">
+        <div className="flex gap-3 font-medium items-center p-1 md:p-2">
+          <div className="flex-none">
+            <UserProfile
+              user={auction.user}
+              displayAvatar
+              displayUsername={false}
+              displayDM
+            />
+          </div>
+          <div className="flex-1 pr-1 flex flex-row justify-between">
+            <div className="flex flex-col">
+              <div className="flex flex-row gap-2 text-sm font-normal items-center">
+                <UserProfile
+                  user={auction.user}
+                  displayAvatar={false}
+                  displayUsername
+                  displayDM
+                />
+                <div className="text-[10px] md:text-xs text-gray-600">
+                  {moment(auction.createdAt).fromNow()}
+                </div>
+              </div>
+              <div className="text-xs md:text-base font-semibold">
+                {getPostTitle(auction)}
+              </div>
+            </div>
+            <div className="flex-none text-xs md:text-base">
+              {getPrice(auction)}
+            </div>
+          </div>
+        </div>
+        {thumbnail && (
+          <div className="flex pl-10 md:pl-14 pr-20 md:pr-20">
+            <div className="relative">
+              <button
+                type="submit"
+                onClick={() => handleOpen()}
+                className="group"
+              >
+                <Thumbnail
+                  image={thumbnail}
+                  sizes={sizes}
+                  width={384}
+                  height={288}
+                />
+                <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+                  <ChatBubbleOvalLeftIcon
+                    color="white"
+                    fill="white"
+                    className="opacity-0 group-hover:opacity-100 w-8 h-8 md:w-9 md:h-9"
+                  />
+                </div>
+              </button>
+              <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+                <PostDetail
+                  auction={auction}
+                  open={open}
+                  handleOpen={handleOpen}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+        {!thumbnail && (
+          <div className="flex px-10 md:px-14 text-xs md:text-sm">
+            <ReadMore text={auction.content} maxLine={0} />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col overflow-hidden shadow line-break">
+      <div className="flex p-1 md:p-2 font-medium">
+        <div className="flex flex-row gap-2 items-center">
+          <UserProfile
+            user={auction.user}
+            displayAvatar
+            displayUsername
+            displayDM
+          />
+          <div className="justify-self-end text-[10px] md:text-xs text-gray-600">
+            {moment(auction.createdAt).fromNow()}
+          </div>
+        </div>
+      </div>
+      {thumbnail && (
+        <div className="flex relative">
+          <button type="submit" onClick={() => handleOpen()} className="group">
+            <Thumbnail
+              image={thumbnail}
+              sizes={sizes}
+              width={384}
+              height={288}
+            />
+            <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+              <ChatBubbleOvalLeftIcon
+                color="white"
+                fill="white"
+                className="opacity-0 group-hover:opacity-100 w-8 h-8 md:w-9 md:h-9"
+              />
+            </div>
+          </button>
+          <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+            <PostDetail auction={auction} open={open} handleOpen={handleOpen} />
+          </div>
+        </div>
+      )}
+      <div className="flex flex-row gap-1 p-1.5 md:p-4 justify-between items-center">
+        <div className="text-xs md:text-base font-semibold">
+          {getPostTitle(auction)}
+        </div>
+        <div className="flex-none text-xs md:text-base">
+          {getPrice(auction)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/auctions/feed.tsx
+++ b/app/components/auctions/feed.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React, { useCallback, useRef } from 'react';
+import { Auction } from 'prisma';
+import { useAppSelector } from '@/redux/hooks';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getAuctions, Auctions } from '@/app/lib/api/auctions';
+import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
+import AuctionPreview from './auction-preview';
+
+function AuctionPreviews({
+  auctions,
+  type,
+  cols,
+}: {
+  auctions: Auctions[] | undefined;
+  type: string;
+  cols: number;
+}) {
+  if (!auctions) return null;
+  return (
+    <>
+      {auctions.map((group) => (
+        <React.Fragment key={group.cursor}>
+          {group.auctions.map((auction: Auction) => (
+            <div className="col-span-1" key={auction.id}>
+              <AuctionPreview type={type} auction={auction} cols={cols} />
+            </div>
+          ))}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+export default function Feed() {
+  const categoryId = useAppSelector(
+    (state) => state.categoriesSlice.categoryId,
+  );
+  const type = useAppSelector((state) => state.postsSlice.type);
+  const cols = useAppSelector((state) => state.postsSlice.cols);
+
+  const { data, fetchNextPage, hasNextPage, status } = useInfiniteQuery(
+    ['auctions', categoryId, type],
+    {
+      queryFn: async ({ pageParam = '' }) =>
+        getAuctions(categoryId ?? '', type, pageParam),
+      getNextPageParam: (lastPage, allPages) => lastPage.cursor,
+    },
+  );
+
+  const ref = useRef<HTMLDivElement>(null);
+  const fetchNext = useCallback(() => {
+    if (!hasNextPage) return;
+    fetchNextPage();
+  }, [hasNextPage, fetchNextPage]);
+
+  useInfiniteScroll(ref, fetchNext);
+
+  if (status === 'loading') {
+    return (
+      <div className="grid gap-4 md:gap-8 lg:gap-12 grid-cols-2 md:grid-cols-2 lg:grid-cols-3 items-start">
+        <div />
+      </div>
+    );
+  }
+  if (status === 'error') return <p>Error ...</p>;
+
+  return (
+    <>
+      <div
+        className={`grid gap-4 md:gap-8 lg:gap-12 ${
+          cols === 1 ? 'grid-cols-1' : 'grid-cols-2'
+        } grid-cols-1 md:grid-cols-2 lg:grid-cols-3 items-start`}
+      >
+        <AuctionPreviews auctions={data.pages} type={type} cols={cols} />
+      </div>
+      <div ref={ref} />
+    </>
+  );
+}

--- a/app/lib/api/auctions.ts
+++ b/app/lib/api/auctions.ts
@@ -1,0 +1,24 @@
+import { Auction } from 'prisma';
+import { client } from '../client';
+
+export type Auctions = {
+  auctions: Auction[];
+  cursor: string;
+  hasNextPage: boolean;
+};
+
+export async function getAuctions(
+  categoryId: string,
+  type: string,
+  cursor: string,
+) {
+  const res = await client.get<Auctions>(
+    `/categories/${categoryId}/posts?type=${type}&cursor=${cursor}`,
+  );
+  return res.data;
+}
+
+export async function getAuction(id: string) {
+  const res = await client.get<Auction>(`/posts/${id}`);
+  return res.data;
+}

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -40,6 +40,10 @@ declare module 'prisma' {
     createdAt: Date;
   }
 
+  interface Auction extends Post {
+    lastBid: number;
+  }
+
   interface Tag {
     id: string;
     name: string;


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
- 추후 경매 기능 구현을 위해 기본 뷰를 확인 및 구현 전 밑작업

## 어떻게 해결했나요?
- 판매 피드를 확인하고 판매 피드를 바탕으로 경매를 위한 컴포넌트를 새로 추가하였습니다.
- 아직 기획이 마무리 않고 API가 없기 때문에 동작하지 않습니다.
- 판매 피드에서 분기처리도 고민했지만 코드의 가독성 부분에서 분리하는게 좋다고 판단되어 분리하였습니다.

## 참고 자료
- 웹동왕 판매 피드