### PR TITLE
feat: post-detail layout 업데이트

### DIFF
--- a/app/components/base/image-carousel.tsx
+++ b/app/components/base/image-carousel.tsx
@@ -116,8 +116,8 @@ export default function ImageCarousel({
           <NextImage
             src={image.url}
             alt={image.name}
-            width={768}
-            height={768}
+            width={width}
+            height={height}
             loading="lazy"
           />
         </div>

--- a/app/components/base/image-carousel.tsx
+++ b/app/components/base/image-carousel.tsx
@@ -78,7 +78,7 @@ export default function ImageCarousel({
     // </Carousel>
     <Carousel
       fullHeightHover={false}
-      swipe
+      swipe={false}
       autoPlay={false}
       navButtonsAlwaysVisible
       indicatorContainerProps={{
@@ -95,6 +95,7 @@ export default function ImageCarousel({
         className: 'absolute md:top-[220px] top-[120px]',
       }}
       animation="slide"
+      duration={200}
       cycleNavigation={false}
       className="full h-full"
       onChange={(index) => {

--- a/app/components/posts/feed.tsx
+++ b/app/components/posts/feed.tsx
@@ -34,7 +34,7 @@ function PostPreviews({
       {posts.map((group) => (
         <React.Fragment key={group.cursor}>
           {group.posts.map((post: Post) => (
-            <div className="col-span-1" key={post.id}>
+            <div className="col-span-1 p-1" key={post.id}>
               <PostPreview type={type} post={post} cols={cols} />
             </div>
           ))}

--- a/app/components/posts/post-detail.tsx
+++ b/app/components/posts/post-detail.tsx
@@ -51,7 +51,7 @@ export default function PostDetailCard({
       }}
     >
       <DialogContent
-        className="p-0 overflow-hidden"
+        className="p-0 overflow-auto md:overflow-hidden"
         sx={{
           padding: '0px 0px',
         }}
@@ -94,7 +94,7 @@ export default function PostDetailCard({
                   </div>
                 </div>
               </div>
-              <div className="p-2 pt-4 text-sm md:text-base h-96 overflow-y-auto">
+              <div className="p-2 pt-4 text-sm md:text-base md:h-[30rem] overflow-y-auto">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {post.content}
                 </ReactMarkdown>

--- a/app/components/posts/post-detail.tsx
+++ b/app/components/posts/post-detail.tsx
@@ -25,15 +25,14 @@ export default function PostDetailCard({
     <Dialog
       open={open}
       onClose={handleOpen}
-      // maxWidth="lg"
       sx={{
         top: '58px',
       }}
-      className="max-w-screen max-h-screen z-60"
+      className="max-w-screen z-60"
       slotProps={{
         backdrop: {
           sx: {
-            background: 'none',
+            background: 'white',
             top: '58px',
           },
         },
@@ -52,28 +51,28 @@ export default function PostDetailCard({
       }}
     >
       <DialogContent
-        className="no-scrollbar p-0 h-full md:pr-10 md:pl-10"
+        className="p-0 overflow-hidden"
         sx={{
           padding: '0px 0px',
         }}
       >
-        <div className="flex justify-end">
+        <div className="flex justify-end p-1 md:px-6">
           <IconButton onClick={handleOpen}>
             <XMarkIcon className="w-6 md:w-8" />
           </IconButton>
         </div>
 
-        <div className="md:flex md:flex-row w-full h-full min-h-[32rem] justify-center">
-          <div className="rounded-tl-md rounded-bl-none rounded-tr-md md:rounded-tl-md md:rounded-bl-md md:rounded-tr-none md:w-[50%] md:pr-[3.334%] md:h-[520px] h-[320px]">
+        <div className="md:flex md:flex-row justify-center">
+          <div className="rounded-tl-md rounded-bl-none rounded-tr-md md:rounded-tl-md md:rounded-bl-md md:rounded-tr-none md:w-[50%]">
             <ImageCarousel
               images={post.images}
               sizes={sizes}
-              width={1920}
-              height={1920}
+              width={760}
+              height={760}
             />
           </div>
-          <div className="flex-none  h-full  border-t-2 md:border-t-0 border-l-0 md:border-l-2 border-gray-100 line-break md:w-[50%] md:pl-[3.334%] pr-5 pl-5">
-            <div className="p-2 font-medium h-full pl-0 pr-0">
+          <div className="flex-none border-t-2 md:border-t-0 border-l-0 md:border-l-2 border-gray-100 line-break md:w-[50%] md:pl-[3.334%] pr-5 pl-5">
+            <div className="p-2 font-medium pl-0 pr-0">
               <div className="border-b-[1px]">
                 <div className="flex flex-row gap-2 text-sm md:text-base items-center">
                   <UserProfile
@@ -95,7 +94,7 @@ export default function PostDetailCard({
                   </div>
                 </div>
               </div>
-              <div className="p-2 pt-4 text-sm md:text-base overflow-y-scroll md:h-[85%] h-[70%] no-scrollbar">
+              <div className="p-2 pt-4 text-sm md:text-base h-96 overflow-y-auto">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {post.content}
                 </ReactMarkdown>

--- a/app/components/posts/post-preview.tsx
+++ b/app/components/posts/post-preview.tsx
@@ -83,9 +83,6 @@ export default function PostPreview({ type, post, cols }: Props) {
                   />
                 </div>
               </button>
-              <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
-                <PostDetail post={post} open={open} handleOpen={handleOpen} />
-              </div>
             </div>
           </div>
         )}
@@ -94,6 +91,9 @@ export default function PostPreview({ type, post, cols }: Props) {
             <ReadMore text={post.content} maxLine={0} />
           </div>
         )}
+        <div>
+          <PostDetail post={post} open={open} handleOpen={handleOpen} />
+        </div>
       </div>
     );
   }
@@ -125,9 +125,6 @@ export default function PostPreview({ type, post, cols }: Props) {
               />
             </div>
           </button>
-          <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
-            <PostDetail post={post} open={open} handleOpen={handleOpen} />
-          </div>
         </div>
       )}
       <div className="flex flex-row gap-1 p-1.5 md:p-4 justify-between items-center">
@@ -135,6 +132,9 @@ export default function PostPreview({ type, post, cols }: Props) {
           {getPostTitle(post)}
         </div>
         <div className="flex-none text-xs md:text-base">{getPrice(post)}</div>
+      </div>
+      <div>
+        <PostDetail post={post} open={open} handleOpen={handleOpen} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. post-detail이 띄워졌을 때, feed 측면이 삐져나와 보임
2. post-detail 전체에 scroll이 걸려있음
3. post-detail 첫 렌더링 때 이미지 나타나는 swipe 효과
4. post-detail 이미지의 실제 크기에 비해 크게 설정된 이미지 사이즈

## 어떻게 해결했나요?
1. PostPreview에 padding 1 설정
2. content에만 overflow-y-auto 설정
3. swipe=false
4. height, width 760으로 조정

## 참고 자료
https://www.npmjs.com/package/react-material-ui-carousel